### PR TITLE
ci: Use arm64 host

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,8 @@ jobs:
           done
   build:
     needs: define-matrix
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ (contains(matrix.component, 'arm64')) && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -35,12 +35,8 @@ COPY --from=builder /go/qemu-arm-static /usr/bin/
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
-RUN apk add curl --no-cache
-RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM --platform=linux/arm64 arm64v8/ruby:3.2-slim-bookworm
-COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 <% else %>
 FROM ruby:3.2-slim-bookworm
 <% end %>
@@ -49,10 +45,6 @@ FROM ruby:3.2-slim-bookworm
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="<%= fluentd_ver %>"
 <% if is_armhf %>
-ARG CROSS_BUILD_START="cross-build-start"
-ARG CROSS_BUILD_END="cross-build-end"
-RUN [ ${CROSS_BUILD_START} ]
-<% elsif is_arm64 %>
 ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
@@ -183,7 +175,7 @@ USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 
-<% if is_armhf || is_arm64 %>
+<% if is_armhf %>
 RUN [ ${CROSS_BUILD_END} ]
 <% end %>
 <% end %>

--- a/v1.18/arm64/debian/Dockerfile
+++ b/v1.18/arm64/debian/Dockerfile
@@ -4,17 +4,10 @@
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
-RUN apk add curl --no-cache
-RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM --platform=linux/arm64 arm64v8/ruby:3.2-slim-bookworm
-COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.18.0"
-ARG CROSS_BUILD_START="cross-build-start"
-ARG CROSS_BUILD_END="cross-build-end"
-RUN [ ${CROSS_BUILD_START} ]
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -75,4 +68,3 @@ USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 
-RUN [ ${CROSS_BUILD_END} ]


### PR DESCRIPTION
Recently, we had a trouble with QEMU on arm64, so let's try arm64 runner to build image.

* Switch runs-on host which depends component
* Drop QEMU related stuff if it is arm64
