### PR TITLE
ci: use machine readabla

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -38,11 +38,20 @@ jobs:
           # v1.19.1-debian-amd64
           IMAGE=$(make echo-all-images | cut -d' ' -f1|cut -d',' -f3)
           echo "# Scan Fluentd image with grype (filter)" >> $GITHUB_STEP_SUMMARY
-          docker run --rm anchore/grype:latest fluent/fluentd:$IMAGE --ignore-states wont-fix | grep -v Negligible >> $GITHUB_STEP_SUMMARY
+          docker run --rm anchore/grype:latest fluent/fluentd:$IMAGE --ignore-states wont-fix | jq -r '
+            (["NAME","INSTALLED","FIXED IN","TYPE","VULNERABILITY","SEVERITY"] | join(" | ") | "| " + . + " |"),
+            (["---","---","---","---","---","---"] | join(" | ") | "| " + . + " |"),
+            (.matches[]
+            | select(.vulnerability.severity != "Negligible")
+            | "| \(.artifact.name) | \(.artifact.version) | \(.vulnerability.fix.versions[0] // "") | \(.artifact.type) | \(.vulnerability.id) | \(.vulnerability.severity)|")
+            ' >> $GITHUB_STEP_SUMMARY
           echo "# Scan Fluentd image with grype (details)" >> $GITHUB_STEP_SUMMARY
-          echo "|NAME | INSTALLED | FIXED | IN | TYPE | VULNERABILITY | SEVERITY | EPSS | RISK | |" >> $GITHUB_STEP_SUMMARY
-          echo "|---| ---|---|---|----|---|---|---|---|---|" >> $GITHUB_STEP_SUMMARY
-          docker run --rm anchore/grype:latest fluent/fluentd:$IMAGE | sed -e "s/won't fix/won'tfix/g" | grep -v "^NAME" | sed 's/^/|/; s/  */ | /g; s/$/ |/' >> $GITHUB_STEP_SUMMARY
+          docker run --rm anchore/grype:latest fluent/fluentd:$IMAGE | jq -r '
+            (["NAME","INSTALLED","FIXED IN","TYPE","VULNERABILITY","SEVERITY"] | join(" | ") | "| " + . + " |"),
+            (["---","---","---","---","---","---"] | join(" | ") | "| " + . + " |"),
+            (.matches[]
+            | "| \(.artifact.name) | \(.artifact.version) | \(.vulnerability.fix.versions[0] // "") | \(.artifact.type) | \(.vulnerability.id) | \(.vulnerability.severity)|")
+            ' >> $GITHUB_STEP_SUMMARY
   ruby:
     name: Scan Ruby image with grype
     strategy:


### PR DESCRIPTION
In the previous versions, ad-hoc and broken Markdown was rendered in some cases.
Use --output json and convert it to GFM.